### PR TITLE
F clang wall wextra compilation fixes

### DIFF
--- a/3rdparty/ultrajsondec.c
+++ b/3rdparty/ultrajsondec.c
@@ -75,12 +75,6 @@ static JSOBJ SetError( struct DecoderState *ds, int offset, const char *message)
   return NULL;
 }
 
-static void ClearError( struct DecoderState *ds)
-{
-  ds->dec->errorOffset = 0;
-  ds->dec->errorStr = NULL;
-}
-
 double createDouble(double intNeg, double intValue, double frcValue, int frcDecimalCount)
 {
   static const double g_pow10[] = {1.0, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001,0.0000001, 0.00000001, 0.000000001, 0.0000000001, 0.00000000001, 0.000000000001, 0.0000000000001, 0.00000000000001, 0.000000000000001};

--- a/src/ujdecode.c
+++ b/src/ujdecode.c
@@ -159,8 +159,9 @@ static void *alloc(struct DecoderState *ds, size_t cbSize)
 	return ret;
 }
 
-static JSOBJ newString(struct DecoderState *ds, wchar_t *start, wchar_t *end)
+static JSOBJ newString(void* context, wchar_t *start, wchar_t *end)
 {
+	struct DecoderState *ds = context;
 	size_t len;
 	StringItem *si = (StringItem *) alloc(ds, sizeof(StringItem) + (end - start + 1) * sizeof(wchar_t));
 	len = end - start;
@@ -187,8 +188,9 @@ static JSOBJ newString(struct DecoderState *ds, wchar_t *start, wchar_t *end)
 	return (JSOBJ) si;
 }
 
-static void objectAddKey(struct DecoderState *ds, JSOBJ obj, JSOBJ name, JSOBJ value)
+static void objectAddKey(void* context, JSOBJ obj, JSOBJ name, JSOBJ value)
 {
+	struct DecoderState *ds = context;
 	ObjectItem *oi = (ObjectItem *) obj;
 	KeyPair *kp = (KeyPair *) alloc(ds, sizeof(KeyPair));
 
@@ -208,8 +210,9 @@ static void objectAddKey(struct DecoderState *ds, JSOBJ obj, JSOBJ name, JSOBJ v
 	oi->tail = kp;
 }
 
-static void arrayAddItem(struct DecoderState *ds, JSOBJ obj, JSOBJ value)
+static void arrayAddItem(void* context, JSOBJ obj, JSOBJ value)
 {
+	struct DecoderState *ds = context;
 	ArrayItem *ai = (ArrayItem *) obj;
 	ArrayEntry *ae = (ArrayEntry *) alloc(ds, sizeof(ArrayEntry));
 
@@ -228,29 +231,33 @@ static void arrayAddItem(struct DecoderState *ds, JSOBJ obj, JSOBJ value)
 
 }
 
-static JSOBJ newTrue(struct DecoderState *ds)
+static JSOBJ newTrue(void* context)
 {
+	struct DecoderState *ds = context;
 	TrueValue *tv = (TrueValue *) alloc(ds, sizeof(TrueValue *));
 	tv->item.type = UJT_True;
 	return (JSOBJ) tv;
 }
 
-static JSOBJ newFalse(struct DecoderState *ds)
+static JSOBJ newFalse(void *context)
 {
+	struct DecoderState *ds = context;
 	FalseValue *fv = (FalseValue *) alloc(ds, sizeof(FalseValue *));
 	fv->item.type = UJT_False;
 	return (JSOBJ) fv;
 }
 
-static JSOBJ newNull(struct DecoderState *ds)
+static JSOBJ newNull(void *context)
 {
+	struct DecoderState *ds = context;
 	NullValue *nv = (NullValue *) alloc(ds, sizeof(NullValue *));
 	nv->item.type = UJT_Null;
 	return (JSOBJ) nv;
 }
 
-static JSOBJ newObject(struct DecoderState *ds)
+static JSOBJ newObject(void *context)
 {
+	struct DecoderState *ds = context;
 	ObjectItem *oi = (ObjectItem *) alloc(ds, sizeof(ObjectItem));
 	oi->item.type = UJT_Object;
 	oi->head = NULL;
@@ -259,8 +266,9 @@ static JSOBJ newObject(struct DecoderState *ds)
 	return (JSOBJ) oi;
 }
 
-static JSOBJ newArray(struct DecoderState *ds)
+static JSOBJ newArray(void *context)
 {
+	struct DecoderState *ds = context;
 	ArrayItem *ai = (ArrayItem *) alloc(ds, sizeof(ArrayItem));
 	ai->head = NULL;
 	ai->tail = NULL;
@@ -268,32 +276,36 @@ static JSOBJ newArray(struct DecoderState *ds)
 	return (JSOBJ) ai;
 }
 
-static JSOBJ newInt(struct DecoderState *ds, JSINT32 value)
+static JSOBJ newInt(void *context, JSINT32 value)
 {
+	struct DecoderState *ds = context;
 	LongValue *lv = (LongValue *) alloc(ds, sizeof(LongValue));
 	lv->item.type = UJT_Long;
 	lv->value = (long) value;
 	return (JSOBJ) lv;
 }
 
-static JSOBJ newLong(struct DecoderState *ds, JSINT64 value)
+static JSOBJ newLong(void *context, JSINT64 value)
 {
+	struct DecoderState *ds = context;
 	LongLongValue *llv = (LongLongValue *) alloc(ds, sizeof(LongLongValue));
 	llv->item.type = UJT_LongLong;
 	llv->value = (long long) value;
 	return (JSOBJ) llv;
 }
 
-static JSOBJ newDouble(struct DecoderState *ds, double value)
+static JSOBJ newDouble(void *context, double value)
 {
+	struct DecoderState *ds = context;
 	DoubleValue *dv = (DoubleValue *) alloc(ds, sizeof(DoubleValue));
 	dv->item.type = UJT_Double;
 	dv->value = (double) value;
 	return (JSOBJ) dv;
 }
 
-static void releaseObject(struct DecoderState *ds, JSOBJ obj)
+static void releaseObject(void *context, JSOBJ obj)
 {
+	struct DecoderState *ds = context;
 	//NOTE: Fix for C4100 warning in L4 MSVC
 	ds = NULL;
 	obj = NULL;

--- a/src/ujdecode.c
+++ b/src/ujdecode.c
@@ -506,7 +506,7 @@ int UJIterObject(void **iter, UJString *outKey, UJObject *outValue)
 	return 1;
 }
 
-long long UJNumericLongLong(UJObject *obj)
+long long UJNumericLongLong(UJObject obj)
 {
 	switch ( ((Item *) obj)->type)
 	{
@@ -519,7 +519,7 @@ long long UJNumericLongLong(UJObject *obj)
 	return 0;
 }
 
-int UJNumericInt(UJObject *obj)
+int UJNumericInt(UJObject obj)
 {
 	switch ( ((Item *) obj)->type)
 	{
@@ -532,7 +532,7 @@ int UJNumericInt(UJObject *obj)
 	return 0;
 }
 
-double UJNumericFloat(UJObject *obj)
+double UJNumericFloat(UJObject obj)
 {
 	switch ( ((Item *) obj)->type)
 	{
@@ -731,7 +731,7 @@ int UJObjectUnpack(UJObject objObj, int keys, const char *format, const wchar_t 
 
 			found ++;
 
-      outValue = va_arg(args, UJObject *);
+      outValue = va_arg(args, UJObject);
 
       if (outValue != NULL)
       {

--- a/src/ujdecode.c
+++ b/src/ujdecode.c
@@ -35,7 +35,7 @@ www.github.com/esnme/ultrajson
 #include "ujdecode.h"
 #include "ultrajson.h"
 #include <math.h>
-#include <malloc.h>
+#include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
 

--- a/src/ujdecode.h
+++ b/src/ujdecode.h
@@ -189,8 +189,6 @@ extern "C" {
 	int UJIterObject(void **iter, UJString *outKey, UJObject *outValue);
 
 	/*
-
-	/*
 	===============================================================================
 	Unpacks an Object by matching the key name with the requested format 
 


### PR DESCRIPTION
these commit allow compilation with clang at the highest warning level

$ clang --version
Apple LLVM version 4.2 (clang-425.0.28) (based on LLVM 3.2svn)
Target: x86_64-apple-darwin11.4.2
Thread model: posix

$ clang -Wall -Wextra src/_.c 3rdparty/_.c -I./3rdparty/ -c
$ 
