### PR TITLE
output parameters must be ordered as keys

### DIFF
--- a/src/ujdecode.c
+++ b/src/ujdecode.c
@@ -687,9 +687,8 @@ int UJObjectUnpack(UJObject objObj, int keys, const char *format, const wchar_t 
 	int ks = 0;
 	const wchar_t *keyNames[64];
   va_list args;
-  UJObject *outValue;
+  UJObject *outValues[64];
 
-  va_start(args, _keyNames);
 
   if (!UJIsObject(objObj))
 	{
@@ -703,10 +702,13 @@ int UJObjectUnpack(UJObject objObj, int keys, const char *format, const wchar_t 
 		return -1;
 	}
 
+	va_start(args, _keyNames);
 	for (ki = 0; ki < keys; ki ++)
 	{
 		keyNames[ki] = _keyNames[ki];
+		outValues[ki] = va_arg(args, UJObject *);
 	}
+	va_end(args);
 	
 	while (UJIterObject(&iter, &key, &value))
 	{
@@ -731,12 +733,10 @@ int UJObjectUnpack(UJObject objObj, int keys, const char *format, const wchar_t 
 
 			found ++;
 
-      outValue = va_arg(args, UJObject);
-
-      if (outValue != NULL)
-      {
-  			*outValue = value;
-      }
+			if (outValues[ki] != NULL)
+			{
+				*outValues[ki] = value;
+			}
 			keyNames[ki] = NULL;
 
 			if (ki == ks)
@@ -745,8 +745,6 @@ int UJObjectUnpack(UJObject objObj, int keys, const char *format, const wchar_t 
 			}
 		}
 	}
-
-  va_end(args);
 
 	return found;
 }


### PR DESCRIPTION
The existing implementation of `UJObjectUnpack` writes to the output parameters as soon as it finds the corresponding element in the `objObj`. 
In my opinion it should use the order sent by the user in the `_keyNames` argument because, otherwise, the meaning of the output parameters changes when the order of the keys in the JSON input changes. Key order should not alter meaning of JSON objects.

I know that this patch alters the meaning of the programs that are already using this function so, if you find it more fair, I can also add a function with a different name.

Thanks!
